### PR TITLE
Add InsuranceSuite skeleton implementing preregistration workflow

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/InsuranceSuite.Api/Controllers/AuthController.cs
+++ b/InsuranceSuite.Api/Controllers/AuthController.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InsuranceSuite.Api.Controllers;
+
+[ApiController]
+[Route("api/auth")]
+public class AuthController : ControllerBase
+{
+    [HttpPost("login")]
+    [AllowAnonymous]
+    public IActionResult Login()
+        => Ok(new { token = "fake-token" });
+
+    [HttpPost("register")]
+    [AllowAnonymous]
+    public IActionResult Register()
+        => Ok();
+}

--- a/InsuranceSuite.Api/Controllers/PreRegistrationsController.cs
+++ b/InsuranceSuite.Api/Controllers/PreRegistrationsController.cs
@@ -1,0 +1,24 @@
+using InsuranceSuite.Application.Features.PreRegistrations.Commands.CreatePreRegistration;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace InsuranceSuite.Api.Controllers;
+
+[ApiController]
+[Route("api/preregistrations")]
+public class PreRegistrationsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public PreRegistrationsController(IMediator mediator)
+        => _mediator = mediator;
+
+    [HttpPost]
+    [Authorize]
+    public async Task<ActionResult<Guid>> Create([FromBody] CreatePreRegistrationCommand command)
+    {
+        var id = await _mediator.Send(command);
+        return Ok(id);
+    }
+}

--- a/InsuranceSuite.Api/InsuranceSuite.Api.csproj
+++ b/InsuranceSuite.Api/InsuranceSuite.Api.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <ItemGroup>
+    <ProjectReference Include="../InsuranceSuite.Application/InsuranceSuite.Application.csproj" />
+    <ProjectReference Include="../InsuranceSuite.Infrastructure/InsuranceSuite.Infrastructure.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0-preview.5.24306.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+  </ItemGroup>
+  <PropertyGroup>
+    <RootNamespace>InsuranceSuite.Api</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/InsuranceSuite.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/InsuranceSuite.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,38 @@
+using InsuranceSuite.Application.Common.Exceptions;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using System.Net;
+
+namespace InsuranceSuite.Api.Middleware;
+
+public static class ExceptionHandlingMiddleware
+{
+    public static void UseExceptionHandling(this IApplicationBuilder app)
+    {
+        app.UseExceptionHandler(builder =>
+        {
+            builder.Run(async context =>
+            {
+                var exception = context.Features.Get<IExceptionHandlerFeature>()?.Error;
+                var status = exception switch
+                {
+                    NotFoundException => (int)HttpStatusCode.NotFound,
+                    ConflictException => (int)HttpStatusCode.Conflict,
+                    FluentValidation.ValidationException => StatusCodes.Status400BadRequest,
+                    _ => (int)HttpStatusCode.InternalServerError
+                };
+
+                var problem = new ProblemDetails
+                {
+                    Status = status,
+                    Title = exception?.GetType().Name,
+                    Detail = exception?.Message
+                };
+
+                context.Response.StatusCode = status;
+                context.Response.ContentType = "application/problem+json";
+                await context.Response.WriteAsJsonAsync(problem);
+            });
+        });
+    }
+}

--- a/InsuranceSuite.Api/Program.cs
+++ b/InsuranceSuite.Api/Program.cs
@@ -1,0 +1,85 @@
+using InsuranceSuite.Api.Middleware;
+using Microsoft.AspNetCore.RateLimiting;
+using System.Threading.RateLimiting;
+using InsuranceSuite.Application.Common.Behaviors;
+using InsuranceSuite.Infrastructure;
+using InsuranceSuite.Infrastructure.Persistence;
+using InsuranceSuite.Infrastructure.Seed;
+using FluentValidation;
+using MediatR;
+using Serilog;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.OpenApi.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseSerilog((ctx, lc) => lc.ReadFrom.Configuration(ctx.Configuration));
+
+builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddMediatR(typeof(InsuranceSuite.Application.Features.PreRegistrations.Commands.CreatePreRegistration.CreatePreRegistrationCommand).Assembly);
+builder.Services.AddValidatorsFromAssembly(typeof(InsuranceSuite.Application.Features.PreRegistrations.Commands.CreatePreRegistration.CreatePreRegistrationCommand).Assembly);
+builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
+builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
+builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(TransactionBehavior<,>));
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "InsuranceSuite API", Version = "v1" });
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header
+    });
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme { Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer" } },
+            new string[] {}
+        }
+    });
+});
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer();
+
+builder.Services.AddAuthorization();
+builder.Services.AddRateLimiter(o =>
+{
+    o.AddFixedWindowLimiter("default", options =>
+    {
+        options.PermitLimit = 100;
+        options.Window = TimeSpan.FromMinutes(1);
+    });
+});
+
+var app = builder.Build();
+
+app.UseExceptionHandling();
+app.UseSerilogRequestLogging();
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseRateLimiter();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapControllers();
+
+using (var scope = app.Services.CreateScope())
+{
+    var context = scope.ServiceProvider.GetRequiredService<InsuranceDbContext>();
+    context.Database.EnsureCreated();
+    await SeedData.InitializeAsync(context);
+}
+
+app.Run();
+
+public partial class Program { }

--- a/InsuranceSuite.Application/Common/Behaviors/LoggingBehavior.cs
+++ b/InsuranceSuite.Application/Common/Behaviors/LoggingBehavior.cs
@@ -1,0 +1,20 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace InsuranceSuite.Application.Common.Behaviors;
+
+public class LoggingBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+{
+    private readonly ILogger<LoggingBehavior<TRequest, TResponse>> _logger;
+
+    public LoggingBehavior(ILogger<LoggingBehavior<TRequest, TResponse>> logger)
+        => _logger = logger;
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Handling {Name}", typeof(TRequest).Name);
+        var response = await next();
+        _logger.LogInformation("Handled {Name}", typeof(TRequest).Name);
+        return response;
+    }
+}

--- a/InsuranceSuite.Application/Common/Behaviors/TransactionBehavior.cs
+++ b/InsuranceSuite.Application/Common/Behaviors/TransactionBehavior.cs
@@ -1,0 +1,19 @@
+using MediatR;
+using InsuranceSuite.Application.Common.Interfaces;
+
+namespace InsuranceSuite.Application.Common.Behaviors;
+
+public class TransactionBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+{
+    private readonly IUnitOfWork _uow;
+
+    public TransactionBehavior(IUnitOfWork uow)
+        => _uow = uow;
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        var response = await next();
+        await _uow.SaveChangesAsync(cancellationToken);
+        return response;
+    }
+}

--- a/InsuranceSuite.Application/Common/Behaviors/ValidationBehavior.cs
+++ b/InsuranceSuite.Application/Common/Behaviors/ValidationBehavior.cs
@@ -1,0 +1,30 @@
+using FluentValidation;
+using MediatR;
+
+namespace InsuranceSuite.Application.Common.Behaviors;
+
+public class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    private readonly IEnumerable<IValidator<TRequest>> _validators;
+
+    public ValidationBehavior(IEnumerable<IValidator<TRequest>> validators)
+        => _validators = validators;
+
+    public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
+    {
+        if (_validators.Any())
+        {
+            var context = new ValidationContext<TRequest>(request);
+            var errors = _validators
+                .Select(v => v.Validate(context))
+                .SelectMany(r => r.Errors)
+                .Where(f => f != null)
+                .ToList();
+
+            if (errors.Count != 0)
+                throw new ValidationException(errors);
+        }
+        return await next();
+    }
+}

--- a/InsuranceSuite.Application/Common/Exceptions/ConflictException.cs
+++ b/InsuranceSuite.Application/Common/Exceptions/ConflictException.cs
@@ -1,0 +1,6 @@
+namespace InsuranceSuite.Application.Common.Exceptions;
+
+public class ConflictException : Exception
+{
+    public ConflictException(string message) : base(message) { }
+}

--- a/InsuranceSuite.Application/Common/Exceptions/NotFoundException.cs
+++ b/InsuranceSuite.Application/Common/Exceptions/NotFoundException.cs
@@ -1,0 +1,6 @@
+namespace InsuranceSuite.Application.Common.Exceptions;
+
+public class NotFoundException : Exception
+{
+    public NotFoundException(string message) : base(message) { }
+}

--- a/InsuranceSuite.Application/Common/Interfaces/IRepository.cs
+++ b/InsuranceSuite.Application/Common/Interfaces/IRepository.cs
@@ -1,0 +1,7 @@
+namespace InsuranceSuite.Application.Common.Interfaces;
+
+public interface IRepository<T> where T : class
+{
+    Task<T?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task AddAsync(T entity, CancellationToken cancellationToken);
+}

--- a/InsuranceSuite.Application/Common/Interfaces/IUnitOfWork.cs
+++ b/InsuranceSuite.Application/Common/Interfaces/IUnitOfWork.cs
@@ -1,0 +1,6 @@
+namespace InsuranceSuite.Application.Common.Interfaces;
+
+public interface IUnitOfWork
+{
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken);
+}

--- a/InsuranceSuite.Application/Common/Mappings/MappingConfig.cs
+++ b/InsuranceSuite.Application/Common/Mappings/MappingConfig.cs
@@ -1,0 +1,13 @@
+using InsuranceSuite.Application.Features.PreRegistrations.Dto;
+using InsuranceSuite.Domain.Entities;
+using Mapster;
+
+namespace InsuranceSuite.Application.Common.Mappings;
+
+public class MappingConfig : IRegister
+{
+    public void Register(TypeAdapterConfig config)
+    {
+        config.NewConfig<PreRegistration, PreRegistrationDto>();
+    }
+}

--- a/InsuranceSuite.Application/Features/PreRegistrations/Commands/CreatePreRegistration/CreatePreRegistrationCommand.cs
+++ b/InsuranceSuite.Application/Features/PreRegistrations/Commands/CreatePreRegistration/CreatePreRegistrationCommand.cs
@@ -1,0 +1,64 @@
+using InsuranceSuite.Application.Common.Exceptions;
+using InsuranceSuite.Application.Common.Interfaces;
+using InsuranceSuite.Domain.Entities;
+using InsuranceSuite.Domain.Enums;
+using MediatR;
+
+namespace InsuranceSuite.Application.Features.PreRegistrations.Commands.CreatePreRegistration;
+
+public record CreatePreRegistrationCommand(Guid UserId, Guid ContractId, Guid SubContractId, Guid? HealthPlanId, string Category) : IRequest<Guid>;
+
+public class CreatePreRegistrationCommandHandler : IRequestHandler<CreatePreRegistrationCommand, Guid>
+{
+    private readonly IRepository<PreRegistration> _preRepo;
+    private readonly IRepository<SubContract> _subRepo;
+    private readonly IRepository<Contract> _contractRepo;
+    private readonly IRepository<HealthPlan> _planRepo;
+
+    public CreatePreRegistrationCommandHandler(
+        IRepository<PreRegistration> preRepo,
+        IRepository<SubContract> subRepo,
+        IRepository<Contract> contractRepo,
+        IRepository<HealthPlan> planRepo)
+    {
+        _preRepo = preRepo;
+        _subRepo = subRepo;
+        _contractRepo = contractRepo;
+        _planRepo = planRepo;
+    }
+
+    public async Task<Guid> Handle(CreatePreRegistrationCommand request, CancellationToken cancellationToken)
+    {
+        var contract = await _contractRepo.GetByIdAsync(request.ContractId, cancellationToken)
+            ?? throw new NotFoundException("Contract not found");
+
+        var sub = await _subRepo.GetByIdAsync(request.SubContractId, cancellationToken)
+            ?? throw new NotFoundException("SubContract not found");
+
+        if (sub.ContractId != contract.Id)
+            throw new ConflictException("SubContract does not belong to contract");
+
+        if (sub.InsuranceType == InsuranceType.HealthSupplement)
+        {
+            if (request.HealthPlanId is null)
+                throw new ConflictException("Health plan required for health supplement");
+
+            var plan = await _planRepo.GetByIdAsync(request.HealthPlanId.Value, cancellationToken)
+                ?? throw new NotFoundException("Health plan not found");
+
+            if (plan.SubContractId != sub.Id)
+                throw new ConflictException("Plan does not belong to subcontract");
+        }
+        else if (request.HealthPlanId is not null)
+        {
+            throw new ConflictException("Health plan must be null for this insurance type");
+        }
+
+        if (DateOnly.FromDateTime(DateTime.UtcNow) > sub.EndDate)
+            throw new ConflictException("Registration window closed");
+
+        var pre = new PreRegistration(request.UserId, request.ContractId, request.SubContractId, request.HealthPlanId, request.Category);
+        await _preRepo.AddAsync(pre, cancellationToken);
+        return pre.Id;
+    }
+}

--- a/InsuranceSuite.Application/Features/PreRegistrations/Commands/CreatePreRegistration/CreatePreRegistrationCommandValidator.cs
+++ b/InsuranceSuite.Application/Features/PreRegistrations/Commands/CreatePreRegistration/CreatePreRegistrationCommandValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+
+namespace InsuranceSuite.Application.Features.PreRegistrations.Commands.CreatePreRegistration;
+
+public class CreatePreRegistrationCommandValidator : AbstractValidator<CreatePreRegistrationCommand>
+{
+    public CreatePreRegistrationCommandValidator()
+    {
+        RuleFor(x => x.UserId).NotEmpty();
+        RuleFor(x => x.ContractId).NotEmpty();
+        RuleFor(x => x.SubContractId).NotEmpty();
+        RuleFor(x => x.Category).NotEmpty().MaximumLength(200);
+    }
+}

--- a/InsuranceSuite.Application/Features/PreRegistrations/Dto/PreRegistrationDto.cs
+++ b/InsuranceSuite.Application/Features/PreRegistrations/Dto/PreRegistrationDto.cs
@@ -1,0 +1,5 @@
+using InsuranceSuite.Domain.Enums;
+
+namespace InsuranceSuite.Application.Features.PreRegistrations.Dto;
+
+public record PreRegistrationDto(Guid Id, Guid UserId, Guid ContractId, Guid SubContractId, Guid? HealthPlanId, string Category, RegistrationStatus Status);

--- a/InsuranceSuite.Application/InsuranceSuite.Application.csproj
+++ b/InsuranceSuite.Application/InsuranceSuite.Application.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="../InsuranceSuite.Domain/InsuranceSuite.Domain.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="12.1.1" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.1" />
+    <PackageReference Include="Mapster" Version="7.4.0" />
+    <PackageReference Include="Mapster.DependencyInjection" Version="7.4.0" />
+  </ItemGroup>
+  <PropertyGroup>
+    <RootNamespace>InsuranceSuite.Application</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/InsuranceSuite.Domain/Entities/Contract.cs
+++ b/InsuranceSuite.Domain/Entities/Contract.cs
@@ -1,0 +1,19 @@
+namespace InsuranceSuite.Domain.Entities;
+
+public class Contract
+{
+    public Guid Id { get; private set; }
+    public string Title { get; private set; } = string.Empty;
+    public Guid CompanyId { get; private set; }
+    public bool IsActive { get; private set; }
+
+    private Contract() { }
+
+    public Contract(string title, Guid companyId)
+    {
+        Id = Guid.NewGuid();
+        Title = title;
+        CompanyId = companyId;
+        IsActive = true;
+    }
+}

--- a/InsuranceSuite.Domain/Entities/HealthPlan.cs
+++ b/InsuranceSuite.Domain/Entities/HealthPlan.cs
@@ -1,0 +1,29 @@
+namespace InsuranceSuite.Domain.Entities;
+
+public class HealthPlan
+{
+    public Guid Id { get; private set; }
+    public Guid SubContractId { get; private set; }
+    public string Title { get; private set; } = string.Empty;
+    public decimal FullPremium { get; private set; }
+    public decimal EmployeeQuota { get; private set; }
+    public decimal CenterQuota { get; private set; }
+    public decimal CompanyQuota { get; private set; }
+    public decimal RefundableFees { get; private set; }
+    public bool IsActive { get; private set; }
+
+    private HealthPlan() { }
+
+    public HealthPlan(Guid subContractId, string title, decimal fullPremium, decimal employeeQuota, decimal centerQuota, decimal companyQuota, decimal refundableFees)
+    {
+        Id = Guid.NewGuid();
+        SubContractId = subContractId;
+        Title = title;
+        FullPremium = fullPremium;
+        EmployeeQuota = employeeQuota;
+        CenterQuota = centerQuota;
+        CompanyQuota = companyQuota;
+        RefundableFees = refundableFees;
+        IsActive = true;
+    }
+}

--- a/InsuranceSuite.Domain/Entities/InsuranceCompany.cs
+++ b/InsuranceSuite.Domain/Entities/InsuranceCompany.cs
@@ -1,0 +1,19 @@
+namespace InsuranceSuite.Domain.Entities;
+
+public class InsuranceCompany
+{
+    public Guid Id { get; private set; }
+    public string Name { get; private set; } = string.Empty;
+    public string Code { get; private set; } = string.Empty;
+    public bool IsActive { get; private set; }
+
+    private InsuranceCompany() { }
+
+    public InsuranceCompany(string name, string code)
+    {
+        Id = Guid.NewGuid();
+        Name = name;
+        Code = code;
+        IsActive = true;
+    }
+}

--- a/InsuranceSuite.Domain/Entities/PreRegistration.cs
+++ b/InsuranceSuite.Domain/Entities/PreRegistration.cs
@@ -1,0 +1,76 @@
+using InsuranceSuite.Domain.Enums;
+
+namespace InsuranceSuite.Domain.Entities;
+
+public class PreRegistration
+{
+    public Guid Id { get; private set; }
+    public Guid UserId { get; private set; }
+    public Guid ContractId { get; private set; }
+    public Guid SubContractId { get; private set; }
+    public Guid? HealthPlanId { get; private set; }
+    public string Category { get; private set; } = string.Empty;
+    public DateTime CreatedAt { get; private set; }
+    public RegistrationStatus Status { get; private set; }
+    public DateTime? LockedAt { get; private set; }
+    public string? Notes { get; private set; }
+
+    private readonly List<RegistrationAudit> _audits = new();
+    public IReadOnlyCollection<RegistrationAudit> Audits => _audits.AsReadOnly();
+
+    private PreRegistration() { }
+
+    public PreRegistration(Guid userId, Guid contractId, Guid subContractId, Guid? healthPlanId, string category)
+    {
+        Id = Guid.NewGuid();
+        UserId = userId;
+        ContractId = contractId;
+        SubContractId = subContractId;
+        HealthPlanId = healthPlanId;
+        Category = category;
+        CreatedAt = DateTime.UtcNow;
+        Status = RegistrationStatus.Draft;
+    }
+
+    public void Submit()
+    {
+        if (Status != RegistrationStatus.Draft)
+            throw new InvalidOperationException("Only drafts can be submitted");
+        Status = RegistrationStatus.Submitted;
+    }
+
+    public void Approve()
+    {
+        if (Status != RegistrationStatus.Submitted)
+            throw new InvalidOperationException("Only submitted registrations can be approved");
+        Status = RegistrationStatus.Approved;
+    }
+
+    public void Lock()
+    {
+        LockedAt = DateTime.UtcNow;
+        Status = RegistrationStatus.Locked;
+    }
+}
+
+public class RegistrationAudit
+{
+    public Guid Id { get; private set; }
+    public Guid PreRegistrationId { get; private set; }
+    public Guid ActorUserId { get; private set; }
+    public string Action { get; private set; } = string.Empty;
+    public DateTime ActionAt { get; private set; }
+    public string DataJson { get; private set; } = string.Empty;
+
+    private RegistrationAudit() { }
+
+    public RegistrationAudit(Guid preRegistrationId, Guid actorUserId, string action, string dataJson)
+    {
+        Id = Guid.NewGuid();
+        PreRegistrationId = preRegistrationId;
+        ActorUserId = actorUserId;
+        Action = action;
+        ActionAt = DateTime.UtcNow;
+        DataJson = dataJson;
+    }
+}

--- a/InsuranceSuite.Domain/Entities/SubContract.cs
+++ b/InsuranceSuite.Domain/Entities/SubContract.cs
@@ -1,0 +1,40 @@
+using InsuranceSuite.Domain.Enums;
+
+namespace InsuranceSuite.Domain.Entities;
+
+public class SubContract
+{
+    public Guid Id { get; private set; }
+    public Guid ContractId { get; private set; }
+    public InsuranceType InsuranceType { get; private set; }
+    public decimal PremiumBase { get; private set; }
+    public DateOnly StartDate { get; private set; }
+    public DateOnly EndDate { get; private set; }
+    public bool IsActive { get; private set; }
+
+    private readonly List<HealthPlan> _plans = new();
+    public IReadOnlyCollection<HealthPlan> Plans => _plans.AsReadOnly();
+
+    private SubContract() { }
+
+    public SubContract(Guid contractId, InsuranceType insuranceType, decimal premiumBase, DateOnly startDate, DateOnly endDate)
+    {
+        if (startDate >= endDate)
+            throw new ArgumentException("Start date must be before end date");
+
+        Id = Guid.NewGuid();
+        ContractId = contractId;
+        InsuranceType = insuranceType;
+        PremiumBase = premiumBase;
+        StartDate = startDate;
+        EndDate = endDate;
+        IsActive = true;
+    }
+
+    public void AddHealthPlan(HealthPlan plan)
+    {
+        if (InsuranceType != InsuranceType.HealthSupplement)
+            throw new InvalidOperationException("Health plans allowed only for HealthSupplement subcontracts");
+        _plans.Add(plan);
+    }
+}

--- a/InsuranceSuite.Domain/Entities/User.cs
+++ b/InsuranceSuite.Domain/Entities/User.cs
@@ -1,0 +1,25 @@
+namespace InsuranceSuite.Domain.Entities;
+
+public class User
+{
+    public Guid Id { get; private set; }
+    public string NationalCode { get; private set; } = string.Empty;
+    public string FullName { get; private set; } = string.Empty;
+    public string Email { get; private set; } = string.Empty;
+    public string Role { get; private set; } = string.Empty;
+    public string PasswordHash { get; private set; } = string.Empty;
+    public bool IsActive { get; private set; }
+
+    private User() { }
+
+    public User(string nationalCode, string fullName, string email, string role, string passwordHash)
+    {
+        Id = Guid.NewGuid();
+        NationalCode = nationalCode;
+        FullName = fullName;
+        Email = email;
+        Role = role;
+        PasswordHash = passwordHash;
+        IsActive = true;
+    }
+}

--- a/InsuranceSuite.Domain/Enums/InsuranceType.cs
+++ b/InsuranceSuite.Domain/Enums/InsuranceType.cs
@@ -1,0 +1,8 @@
+namespace InsuranceSuite.Domain.Enums;
+
+public enum InsuranceType
+{
+    HealthSupplement = 0,
+    LifeAccident = 1,
+    Fire = 2
+}

--- a/InsuranceSuite.Domain/Enums/RegistrationStatus.cs
+++ b/InsuranceSuite.Domain/Enums/RegistrationStatus.cs
@@ -1,0 +1,11 @@
+namespace InsuranceSuite.Domain.Enums;
+
+public enum RegistrationStatus
+{
+    Draft = 0,
+    Submitted = 1,
+    Approved = 2,
+    Rejected = 3,
+    Finalized = 4,
+    Locked = 5
+}

--- a/InsuranceSuite.Domain/InsuranceSuite.Domain.csproj
+++ b/InsuranceSuite.Domain/InsuranceSuite.Domain.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>InsuranceSuite.Domain</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/InsuranceSuite.Infrastructure/DependencyInjection.cs
+++ b/InsuranceSuite.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,29 @@
+using InsuranceSuite.Application.Common.Interfaces;
+using InsuranceSuite.Infrastructure.Persistence;
+using InsuranceSuite.Infrastructure.Repositories;
+using Mapster;
+using MapsterMapper;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace InsuranceSuite.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddDbContext<InsuranceDbContext>(options =>
+            options.UseSqlServer(configuration.GetConnectionString("DefaultConnection")));
+
+        services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
+        services.AddScoped<IUnitOfWork, UnitOfWork>();
+
+        var config = TypeAdapterConfig.GlobalSettings;
+        config.Scan(typeof(InsuranceSuite.Application.Common.Mappings.MappingConfig).Assembly);
+        services.AddSingleton(config);
+        services.AddScoped<IMapper, ServiceMapper>();
+
+        return services;
+    }
+}

--- a/InsuranceSuite.Infrastructure/InsuranceSuite.Infrastructure.csproj
+++ b/InsuranceSuite.Infrastructure/InsuranceSuite.Infrastructure.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="../InsuranceSuite.Domain/InsuranceSuite.Domain.csproj" />
+    <ProjectReference Include="../InsuranceSuite.Application/InsuranceSuite.Application.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.5.24306.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-preview.5.24306.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-preview.5.24306.11" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+  </ItemGroup>
+  <PropertyGroup>
+    <RootNamespace>InsuranceSuite.Infrastructure</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/InsuranceSuite.Infrastructure/Persistence/Configurations/HealthPlanConfiguration.cs
+++ b/InsuranceSuite.Infrastructure/Persistence/Configurations/HealthPlanConfiguration.cs
@@ -1,0 +1,20 @@
+using InsuranceSuite.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace InsuranceSuite.Infrastructure.Persistence.Configurations;
+
+public class HealthPlanConfiguration : IEntityTypeConfiguration<HealthPlan>
+{
+    public void Configure(EntityTypeBuilder<HealthPlan> builder)
+    {
+        builder.ToTable("HealthPlans");
+        builder.HasKey(h => h.Id);
+        builder.Property(h => h.Title).HasMaxLength(200).IsRequired();
+        builder.HasIndex(h => new { h.SubContractId, h.Title }).IsUnique();
+        builder.HasOne<SubContract>()
+            .WithMany(s => s.Plans)
+            .HasForeignKey(h => h.SubContractId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/InsuranceSuite.Infrastructure/Persistence/InsuranceDbContext.cs
+++ b/InsuranceSuite.Infrastructure/Persistence/InsuranceDbContext.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using InsuranceSuite.Domain.Entities;
+
+namespace InsuranceSuite.Infrastructure.Persistence;
+
+public class InsuranceDbContext : DbContext
+{
+    public InsuranceDbContext(DbContextOptions<InsuranceDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<InsuranceCompany> InsuranceCompanies => Set<InsuranceCompany>();
+    public DbSet<Contract> Contracts => Set<Contract>();
+    public DbSet<SubContract> SubContracts => Set<SubContract>();
+    public DbSet<HealthPlan> HealthPlans => Set<HealthPlan>();
+    public DbSet<User> Users => Set<User>();
+    public DbSet<PreRegistration> PreRegistrations => Set<PreRegistration>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(InsuranceDbContext).Assembly);
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/InsuranceSuite.Infrastructure/Repositories/Repository.cs
+++ b/InsuranceSuite.Infrastructure/Repositories/Repository.cs
@@ -1,0 +1,23 @@
+using InsuranceSuite.Application.Common.Interfaces;
+using InsuranceSuite.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace InsuranceSuite.Infrastructure.Repositories;
+
+public class Repository<T> : IRepository<T> where T : class
+{
+    private readonly InsuranceDbContext _context;
+    private readonly DbSet<T> _set;
+
+    public Repository(InsuranceDbContext context)
+    {
+        _context = context;
+        _set = context.Set<T>();
+    }
+
+    public async Task<T?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+        => await _set.FindAsync(new object?[] { id }, cancellationToken);
+
+    public async Task AddAsync(T entity, CancellationToken cancellationToken)
+        => await _set.AddAsync(entity, cancellationToken);
+}

--- a/InsuranceSuite.Infrastructure/Repositories/UnitOfWork.cs
+++ b/InsuranceSuite.Infrastructure/Repositories/UnitOfWork.cs
@@ -1,0 +1,15 @@
+using InsuranceSuite.Application.Common.Interfaces;
+using InsuranceSuite.Infrastructure.Persistence;
+
+namespace InsuranceSuite.Infrastructure.Repositories;
+
+public class UnitOfWork : IUnitOfWork
+{
+    private readonly InsuranceDbContext _context;
+
+    public UnitOfWork(InsuranceDbContext context)
+        => _context = context;
+
+    public Task<int> SaveChangesAsync(CancellationToken cancellationToken)
+        => _context.SaveChangesAsync(cancellationToken);
+}

--- a/InsuranceSuite.Infrastructure/Seed/SeedData.cs
+++ b/InsuranceSuite.Infrastructure/Seed/SeedData.cs
@@ -1,0 +1,29 @@
+using InsuranceSuite.Domain.Entities;
+using InsuranceSuite.Domain.Enums;
+using InsuranceSuite.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace InsuranceSuite.Infrastructure.Seed;
+
+public static class SeedData
+{
+    public static async Task InitializeAsync(InsuranceDbContext context)
+    {
+        if (await context.Users.AnyAsync()) return;
+
+        var admin = new User("0000000000", "Admin User", "admin@example.com", "Admin", "HASH");
+        context.Users.Add(admin);
+
+        var company = new InsuranceCompany("Sample Company", "SC01");
+        context.InsuranceCompanies.Add(company);
+
+        var contract = new Contract("Main Contract", company.Id);
+        context.Contracts.Add(contract);
+
+        var sub = new SubContract(contract.Id, InsuranceType.HealthSupplement, 1000000m, new DateOnly(2024,1,1), new DateOnly(2024,12,31));
+        context.SubContracts.Add(sub);
+
+        var plan = new HealthPlan(sub.Id, "Base Plan", 1000000m, 300000m, 300000m, 400000m, 0m);
+        sub.AddHealthPlan(plan);
+    }
+}

--- a/InsuranceSuite.Tests.Integration/CustomWebApplicationFactory.cs
+++ b/InsuranceSuite.Tests.Integration/CustomWebApplicationFactory.cs
@@ -1,0 +1,34 @@
+using InsuranceSuite.Infrastructure.Persistence;
+using InsuranceSuite.Infrastructure.Seed;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace InsuranceSuite.Tests.Integration;
+
+public class CustomWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<InsuranceDbContext>));
+            if (descriptor != null)
+                services.Remove(descriptor);
+
+            services.AddDbContext<InsuranceDbContext>(options =>
+                options.UseInMemoryDatabase("TestDb" + Guid.NewGuid()));
+
+            services.AddAuthentication("Test")
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("Test", options => { });
+
+            var sp = services.BuildServiceProvider();
+            using var scope = sp.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<InsuranceDbContext>();
+            db.Database.EnsureCreated();
+            SeedData.InitializeAsync(db).GetAwaiter().GetResult();
+        });
+    }
+}

--- a/InsuranceSuite.Tests.Integration/Features/PreRegistrations/CreatePreRegistrationTests.cs
+++ b/InsuranceSuite.Tests.Integration/Features/PreRegistrations/CreatePreRegistrationTests.cs
@@ -1,0 +1,30 @@
+using System.Net.Http.Json;
+using InsuranceSuite.Application.Features.PreRegistrations.Commands.CreatePreRegistration;
+using InsuranceSuite.Infrastructure.Persistence;
+using Xunit;
+
+namespace InsuranceSuite.Tests.Integration.Features.PreRegistrations;
+
+public class CreatePreRegistrationTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly CustomWebApplicationFactory _factory;
+
+    public CreatePreRegistrationTests(CustomWebApplicationFactory factory)
+        => _factory = factory;
+
+    [Fact]
+    public async Task Creates_pre_registration()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<InsuranceDbContext>();
+        var user = context.Users.First();
+        var contract = context.Contracts.First();
+        var sub = context.SubContracts.First();
+        var plan = context.HealthPlans.First();
+
+        var client = _factory.CreateClient();
+        var cmd = new CreatePreRegistrationCommand(user.Id, contract.Id, sub.Id, plan.Id, "Employee");
+        var response = await client.PostAsJsonAsync("/api/preregistrations", cmd);
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/InsuranceSuite.Tests.Integration/InsuranceSuite.Tests.Integration.csproj
+++ b/InsuranceSuite.Tests.Integration/InsuranceSuite.Tests.Integration.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="../InsuranceSuite.Api/InsuranceSuite.Api.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0-preview.5.24306.4" />
+    <PackageReference Include="Respawn" Version="7.0.0" />
+    <PackageReference Include="Testcontainers" Version="3.7.0" />
+  </ItemGroup>
+  <PropertyGroup>
+    <RootNamespace>InsuranceSuite.Tests.Integration</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/InsuranceSuite.Tests.Integration/TestAuthHandler.cs
+++ b/InsuranceSuite.Tests.Integration/TestAuthHandler.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+
+namespace InsuranceSuite.Tests.Integration;
+
+public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
+        : base(options, logger, encoder, clock)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[] { new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()), new Claim(ClaimTypes.Role, "Admin") };
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/InsuranceSuite.sln
+++ b/InsuranceSuite.sln
@@ -1,0 +1,42 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31919.166
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InsuranceSuite.Domain", "InsuranceSuite.Domain/InsuranceSuite.Domain.csproj", "{41C88835-1044-44D3-B280-53C3255D8E6D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InsuranceSuite.Application", "InsuranceSuite.Application/InsuranceSuite.Application.csproj", "{AAE19BA0-A352-4D45-933B-46787A7E1F9E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InsuranceSuite.Infrastructure", "InsuranceSuite.Infrastructure/InsuranceSuite.Infrastructure.csproj", "{44833147-6822-4195-AD2E-8D1157FC1445}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InsuranceSuite.Api", "InsuranceSuite.Api/InsuranceSuite.Api.csproj", "{40817B49-BD86-47B3-A909-91F30A54509D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InsuranceSuite.Tests.Integration", "InsuranceSuite.Tests.Integration/InsuranceSuite.Tests.Integration.csproj", "{C5D38504-128C-4DFF-8AEA-5F95379CE828}"
+EndProject
+Global
+  GlobalSection(SolutionConfigurationPlatforms) = preSolution
+    Debug|Any CPU = Debug|Any CPU
+    Release|Any CPU = Release|Any CPU
+  EndGlobalSection
+  GlobalSection(ProjectConfigurationPlatforms) = postSolution
+    {41C88835-1044-44D3-B280-53C3255D8E6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {41C88835-1044-44D3-B280-53C3255D8E6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {41C88835-1044-44D3-B280-53C3255D8E6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {41C88835-1044-44D3-B280-53C3255D8E6D}.Release|Any CPU.Build.0 = Release|Any CPU
+    {AAE19BA0-A352-4D45-933B-46787A7E1F9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {AAE19BA0-A352-4D45-933B-46787A7E1F9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {AAE19BA0-A352-4D45-933B-46787A7E1F9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {AAE19BA0-A352-4D45-933B-46787A7E1F9E}.Release|Any CPU.Build.0 = Release|Any CPU
+    {44833147-6822-4195-AD2E-8D1157FC1445}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {44833147-6822-4195-AD2E-8D1157FC1445}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {44833147-6822-4195-AD2E-8D1157FC1445}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {44833147-6822-4195-AD2E-8D1157FC1445}.Release|Any CPU.Build.0 = Release|Any CPU
+    {40817B49-BD86-47B3-A909-91F30A54509D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {40817B49-BD86-47B3-A909-91F30A54509D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {40817B49-BD86-47B3-A909-91F30A54509D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {40817B49-BD86-47B3-A909-91F30A54509D}.Release|Any CPU.Build.0 = Release|Any CPU
+    {C5D38504-128C-4DFF-8AEA-5F95379CE828}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+    {C5D38504-128C-4DFF-8AEA-5F95379CE828}.Debug|Any CPU.Build.0 = Debug|Any CPU
+    {C5D38504-128C-4DFF-8AEA-5F95379CE828}.Release|Any CPU.ActiveCfg = Release|Any CPU
+    {C5D38504-128C-4DFF-8AEA-5F95379CE828}.Release|Any CPU.Build.0 = Release|Any CPU
+  EndGlobalSection
+EndGlobal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.9'
+services:
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=YourStrong!Passw0rd
+    ports:
+      - "1433:1433"
+    healthcheck:
+      test: ["CMD", "/opt/mssql-tools/bin/sqlcmd", "-S", "localhost", "-U", "sa", "-P", "YourStrong!Passw0rd", "-Q", "select 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10


### PR DESCRIPTION
## Summary
- scaffold Clean Architecture solution with Domain, Application, Infrastructure, API and Integration Test projects
- implement core entities and CQRS command for insurance preregistration with validation and infrastructure wiring
- add API endpoints, global exception middleware, rate limiting, and sample seed data

## Testing
- `dotnet build` *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_689c6d4e3da08321b90764c1c2941730