### PR TITLE
Add full CRUD support for pre-registrations

### DIFF
--- a/InsuranceSuite.Api/Controllers/PreRegistrationsController.cs
+++ b/InsuranceSuite.Api/Controllers/PreRegistrationsController.cs
@@ -1,4 +1,10 @@
 using InsuranceSuite.Application.Features.PreRegistrations.Commands.CreatePreRegistration;
+using InsuranceSuite.Application.Features.PreRegistrations.Commands.UpdatePreRegistration;
+using InsuranceSuite.Application.Features.PreRegistrations.Commands.DeletePreRegistration;
+using InsuranceSuite.Application.Features.PreRegistrations.Queries.GetPreRegistrationById;
+using InsuranceSuite.Application.Features.PreRegistrations.Queries.GetPreRegistrations;
+using InsuranceSuite.Application.Features.PreRegistrations.Dto;
+using System.Collections.Generic;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -14,11 +20,46 @@ public class PreRegistrationsController : ControllerBase
     public PreRegistrationsController(IMediator mediator)
         => _mediator = mediator;
 
+    [HttpGet]
+    [Authorize]
+    public async Task<ActionResult<List<PreRegistrationDto>>> GetAll()
+    {
+        var list = await _mediator.Send(new GetPreRegistrationsQuery());
+        return Ok(list);
+    }
+
+    [HttpGet("{id:guid}")]
+    [Authorize]
+    public async Task<ActionResult<PreRegistrationDto>> Get(Guid id)
+    {
+        var pre = await _mediator.Send(new GetPreRegistrationByIdQuery(id));
+        return Ok(pre);
+    }
+
     [HttpPost]
     [Authorize]
     public async Task<ActionResult<Guid>> Create([FromBody] CreatePreRegistrationCommand command)
     {
         var id = await _mediator.Send(command);
         return Ok(id);
+    }
+
+    [HttpPut("{id:guid}")]
+    [Authorize]
+    public async Task<IActionResult> Update(Guid id, [FromBody] UpdatePreRegistrationCommand command)
+    {
+        if (id != command.Id)
+            return BadRequest();
+
+        await _mediator.Send(command);
+        return NoContent();
+    }
+
+    [HttpDelete("{id:guid}")]
+    [Authorize]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        await _mediator.Send(new DeletePreRegistrationCommand(id));
+        return NoContent();
     }
 }

--- a/InsuranceSuite.Application/Common/Interfaces/IRepository.cs
+++ b/InsuranceSuite.Application/Common/Interfaces/IRepository.cs
@@ -3,5 +3,8 @@ namespace InsuranceSuite.Application.Common.Interfaces;
 public interface IRepository<T> where T : class
 {
     Task<T?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task<List<T>> GetAllAsync(CancellationToken cancellationToken);
     Task AddAsync(T entity, CancellationToken cancellationToken);
+    Task UpdateAsync(T entity, CancellationToken cancellationToken);
+    Task DeleteAsync(T entity, CancellationToken cancellationToken);
 }

--- a/InsuranceSuite.Application/Features/PreRegistrations/Commands/DeletePreRegistration/DeletePreRegistrationCommand.cs
+++ b/InsuranceSuite.Application/Features/PreRegistrations/Commands/DeletePreRegistration/DeletePreRegistrationCommand.cs
@@ -1,0 +1,25 @@
+using InsuranceSuite.Application.Common.Exceptions;
+using InsuranceSuite.Application.Common.Interfaces;
+using InsuranceSuite.Domain.Entities;
+using MediatR;
+
+namespace InsuranceSuite.Application.Features.PreRegistrations.Commands.DeletePreRegistration;
+
+public record DeletePreRegistrationCommand(Guid Id) : IRequest;
+
+public class DeletePreRegistrationCommandHandler : IRequestHandler<DeletePreRegistrationCommand>
+{
+    private readonly IRepository<PreRegistration> _preRepo;
+
+    public DeletePreRegistrationCommandHandler(IRepository<PreRegistration> preRepo)
+        => _preRepo = preRepo;
+
+    public async Task<Unit> Handle(DeletePreRegistrationCommand request, CancellationToken cancellationToken)
+    {
+        var pre = await _preRepo.GetByIdAsync(request.Id, cancellationToken)
+            ?? throw new NotFoundException("PreRegistration not found");
+
+        await _preRepo.DeleteAsync(pre, cancellationToken);
+        return Unit.Value;
+    }
+}

--- a/InsuranceSuite.Application/Features/PreRegistrations/Commands/DeletePreRegistration/DeletePreRegistrationCommandValidator.cs
+++ b/InsuranceSuite.Application/Features/PreRegistrations/Commands/DeletePreRegistration/DeletePreRegistrationCommandValidator.cs
@@ -1,0 +1,11 @@
+using FluentValidation;
+
+namespace InsuranceSuite.Application.Features.PreRegistrations.Commands.DeletePreRegistration;
+
+public class DeletePreRegistrationCommandValidator : AbstractValidator<DeletePreRegistrationCommand>
+{
+    public DeletePreRegistrationCommandValidator()
+    {
+        RuleFor(x => x.Id).NotEmpty();
+    }
+}

--- a/InsuranceSuite.Application/Features/PreRegistrations/Commands/UpdatePreRegistration/UpdatePreRegistrationCommand.cs
+++ b/InsuranceSuite.Application/Features/PreRegistrations/Commands/UpdatePreRegistration/UpdatePreRegistrationCommand.cs
@@ -1,0 +1,68 @@
+using InsuranceSuite.Application.Common.Exceptions;
+using InsuranceSuite.Application.Common.Interfaces;
+using InsuranceSuite.Domain.Entities;
+using InsuranceSuite.Domain.Enums;
+using MediatR;
+
+namespace InsuranceSuite.Application.Features.PreRegistrations.Commands.UpdatePreRegistration;
+
+public record UpdatePreRegistrationCommand(Guid Id, Guid ContractId, Guid SubContractId, Guid? HealthPlanId, string Category) : IRequest;
+
+public class UpdatePreRegistrationCommandHandler : IRequestHandler<UpdatePreRegistrationCommand>
+{
+    private readonly IRepository<PreRegistration> _preRepo;
+    private readonly IRepository<SubContract> _subRepo;
+    private readonly IRepository<Contract> _contractRepo;
+    private readonly IRepository<HealthPlan> _planRepo;
+
+    public UpdatePreRegistrationCommandHandler(
+        IRepository<PreRegistration> preRepo,
+        IRepository<SubContract> subRepo,
+        IRepository<Contract> contractRepo,
+        IRepository<HealthPlan> planRepo)
+    {
+        _preRepo = preRepo;
+        _subRepo = subRepo;
+        _contractRepo = contractRepo;
+        _planRepo = planRepo;
+    }
+
+    public async Task<Unit> Handle(UpdatePreRegistrationCommand request, CancellationToken cancellationToken)
+    {
+        var pre = await _preRepo.GetByIdAsync(request.Id, cancellationToken)
+            ?? throw new NotFoundException("PreRegistration not found");
+
+        var contract = await _contractRepo.GetByIdAsync(request.ContractId, cancellationToken)
+            ?? throw new NotFoundException("Contract not found");
+
+        var sub = await _subRepo.GetByIdAsync(request.SubContractId, cancellationToken)
+            ?? throw new NotFoundException("SubContract not found");
+
+        if (sub.ContractId != contract.Id)
+            throw new ConflictException("SubContract does not belong to contract");
+
+        if (sub.InsuranceType == InsuranceType.HealthSupplement)
+        {
+            if (request.HealthPlanId is null)
+                throw new ConflictException("Health plan required for health supplement");
+
+            var plan = await _planRepo.GetByIdAsync(request.HealthPlanId.Value, cancellationToken)
+                ?? throw new NotFoundException("Health plan not found");
+
+            if (plan.SubContractId != sub.Id)
+                throw new ConflictException("Plan does not belong to subcontract");
+        }
+        else if (request.HealthPlanId is not null)
+        {
+            throw new ConflictException("Health plan must be null for this insurance type");
+        }
+
+        if (DateOnly.FromDateTime(DateTime.UtcNow) > sub.EndDate)
+            throw new ConflictException("Registration window closed");
+
+        pre.Update(request.ContractId, request.SubContractId, request.HealthPlanId, request.Category);
+        await _preRepo.UpdateAsync(pre, cancellationToken);
+
+        return Unit.Value;
+    }
+}

--- a/InsuranceSuite.Application/Features/PreRegistrations/Commands/UpdatePreRegistration/UpdatePreRegistrationCommandValidator.cs
+++ b/InsuranceSuite.Application/Features/PreRegistrations/Commands/UpdatePreRegistration/UpdatePreRegistrationCommandValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+
+namespace InsuranceSuite.Application.Features.PreRegistrations.Commands.UpdatePreRegistration;
+
+public class UpdatePreRegistrationCommandValidator : AbstractValidator<UpdatePreRegistrationCommand>
+{
+    public UpdatePreRegistrationCommandValidator()
+    {
+        RuleFor(x => x.Id).NotEmpty();
+        RuleFor(x => x.ContractId).NotEmpty();
+        RuleFor(x => x.SubContractId).NotEmpty();
+        RuleFor(x => x.Category).NotEmpty().MaximumLength(200);
+    }
+}

--- a/InsuranceSuite.Application/Features/PreRegistrations/Queries/GetPreRegistrationById/GetPreRegistrationByIdQuery.cs
+++ b/InsuranceSuite.Application/Features/PreRegistrations/Queries/GetPreRegistrationById/GetPreRegistrationByIdQuery.cs
@@ -1,0 +1,26 @@
+using InsuranceSuite.Application.Common.Exceptions;
+using InsuranceSuite.Application.Common.Interfaces;
+using InsuranceSuite.Application.Features.PreRegistrations.Dto;
+using InsuranceSuite.Domain.Entities;
+using Mapster;
+using MediatR;
+
+namespace InsuranceSuite.Application.Features.PreRegistrations.Queries.GetPreRegistrationById;
+
+public record GetPreRegistrationByIdQuery(Guid Id) : IRequest<PreRegistrationDto>;
+
+public class GetPreRegistrationByIdQueryHandler : IRequestHandler<GetPreRegistrationByIdQuery, PreRegistrationDto>
+{
+    private readonly IRepository<PreRegistration> _preRepo;
+
+    public GetPreRegistrationByIdQueryHandler(IRepository<PreRegistration> preRepo)
+        => _preRepo = preRepo;
+
+    public async Task<PreRegistrationDto> Handle(GetPreRegistrationByIdQuery request, CancellationToken cancellationToken)
+    {
+        var pre = await _preRepo.GetByIdAsync(request.Id, cancellationToken)
+            ?? throw new NotFoundException("PreRegistration not found");
+
+        return pre.Adapt<PreRegistrationDto>();
+    }
+}

--- a/InsuranceSuite.Application/Features/PreRegistrations/Queries/GetPreRegistrations/GetPreRegistrationsQuery.cs
+++ b/InsuranceSuite.Application/Features/PreRegistrations/Queries/GetPreRegistrations/GetPreRegistrationsQuery.cs
@@ -1,0 +1,23 @@
+using InsuranceSuite.Application.Common.Interfaces;
+using InsuranceSuite.Application.Features.PreRegistrations.Dto;
+using InsuranceSuite.Domain.Entities;
+using Mapster;
+using MediatR;
+
+namespace InsuranceSuite.Application.Features.PreRegistrations.Queries.GetPreRegistrations;
+
+public record GetPreRegistrationsQuery() : IRequest<List<PreRegistrationDto>>;
+
+public class GetPreRegistrationsQueryHandler : IRequestHandler<GetPreRegistrationsQuery, List<PreRegistrationDto>>
+{
+    private readonly IRepository<PreRegistration> _preRepo;
+
+    public GetPreRegistrationsQueryHandler(IRepository<PreRegistration> preRepo)
+        => _preRepo = preRepo;
+
+    public async Task<List<PreRegistrationDto>> Handle(GetPreRegistrationsQuery request, CancellationToken cancellationToken)
+    {
+        var pres = await _preRepo.GetAllAsync(cancellationToken);
+        return pres.Adapt<List<PreRegistrationDto>>();
+    }
+}

--- a/InsuranceSuite.Domain/Entities/PreRegistration.cs
+++ b/InsuranceSuite.Domain/Entities/PreRegistration.cs
@@ -32,6 +32,14 @@ public class PreRegistration
         Status = RegistrationStatus.Draft;
     }
 
+    public void Update(Guid contractId, Guid subContractId, Guid? healthPlanId, string category)
+    {
+        ContractId = contractId;
+        SubContractId = subContractId;
+        HealthPlanId = healthPlanId;
+        Category = category;
+    }
+
     public void Submit()
     {
         if (Status != RegistrationStatus.Draft)

--- a/InsuranceSuite.Infrastructure/Repositories/Repository.cs
+++ b/InsuranceSuite.Infrastructure/Repositories/Repository.cs
@@ -18,6 +18,21 @@ public class Repository<T> : IRepository<T> where T : class
     public async Task<T?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
         => await _set.FindAsync(new object?[] { id }, cancellationToken);
 
+    public async Task<List<T>> GetAllAsync(CancellationToken cancellationToken)
+        => await _set.ToListAsync(cancellationToken);
+
     public async Task AddAsync(T entity, CancellationToken cancellationToken)
         => await _set.AddAsync(entity, cancellationToken);
+
+    public Task UpdateAsync(T entity, CancellationToken cancellationToken)
+    {
+        _set.Update(entity);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(T entity, CancellationToken cancellationToken)
+    {
+        _set.Remove(entity);
+        return Task.CompletedTask;
+    }
 }


### PR DESCRIPTION
## Summary
- add GET, PUT, DELETE endpoints for pre-registrations API
- implement update and delete command handlers plus queries for list and detail views
- expand repository pattern and domain model to support full CRUD

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ddb23432c8321a5cb08ac0205622b